### PR TITLE
Add missing English translations and ConfirmDeletePermanently key

### DIFF
--- a/ContextMenuManager/Properties/Resources/Texts/AppLanguageDic.ini
+++ b/ContextMenuManager/Properties/Resources/Texts/AppLanguageDic.ini
@@ -215,6 +215,7 @@ CommandCannotBeEmpty = 菜单命令不能为空！
 StringParsingFailed = 本地化字符串解析失败！
 TextLengthCannotExceed80 = 菜单文本过长，长度不允许超过80！
 ConfirmDeleteBackupPermanently = 确认是否永久删除此项？\r\n此操作无法还原，请谨慎操作！
+ConfirmDeletePermanently = 确认是否永久删除此项？\r\n此操作无法还原，请谨慎操作！
 DeleteButCanRestore = 确认删除此菜单的注册表项目？\r\n由于启用了自动备份（默认启用），\r\n删除后可在备份文件夹中还原。
 ConfirmDeleteReference = 确认是否移除对该项目的引用？
 ConfirmDelete = 确认是否删除该项？

--- a/ContextMenuManager/Properties/Resources/Texts/DetailedEditDic.xml
+++ b/ContextMenuManager/Properties/Resources/Texts/DetailedEditDic.xml
@@ -23,6 +23,9 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     </Item>
     <Item>
       <Text Value='使用经典紧凑右键菜单'/>
+      <Text Value='Use classic compact context menu'>
+        <Culture>en-US</Culture>
+      </Text>
       <RestartExplorer/>
       <OSVersion Compare='&gt;='>10.0.14393</OSVersion>
       <OSVersion Compare='&lt;'>10.0.17763</OSVersion>
@@ -30,19 +33,34 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     </Item>
     <Item>
       <Text Value='右键菜单在左侧弹出'/>
+      <Text Value='Context menu opens on the left'>
+        <Culture>en-US</Culture>
+      </Text>
       <Tip Value='更改后需要重新登录账户生效'/>
+      <Tip Value='You need to log out and back in for the change to take effect'>
+        <Culture>en-US</Culture>
+      </Tip>
       <OSVersion Compare='&gt;='>10.0</OSVersion>
       <Rule RegPath='HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Windows' ValueName='MenuDropAlignment' On='1'/>
       <Process FileName='explorer.exe' Arguments='shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}'/>
     </Item>
     <Item>
       <Text Value='Shell类型菜单同时操作文件对象数量限制'/>
+      <Text Value='Limit on simultaneous Shell menu operations on file objects'>
+        <Culture>en-US</Culture>
+      </Text>
       <Tip Value='系统默认值为15，超过15为无限制'/>
+      <Tip Value='System default is 15; values above 15 mean unlimited'>
+        <Culture>en-US</Culture>
+      </Tip>
       <IsNumberItem/>
       <Rule RegPath='HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer' ValueName='MultipleInvokePromptMinimum' Max='32767' Min='1' Default='15'/>
     </Item>
     <Item>
       <Text Value='创建快捷方式时去除 "快捷方式" 后缀'/>
+      <Text Value='Remove "- Shortcut" suffix when creating shortcuts'>
+        <Culture>en-US</Culture>
+      </Text>
       <RestartExplorer/>
       <Rule RegPath='\NamingTemplates' ValueName='ShortcutNameTemplate' On='%s' ValueKind='REG_SZ'/>
       <Rule RegPath='HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\NamingTemplates' ValueName='ShortcutNameTemplate' On='%s' ValueKind='REG_SZ'/>
@@ -50,12 +68,21 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     </Item>
     <Item>
       <Text Value='文件(夹) 复制粘贴去除 "副本" 后缀'/>
+      <Text Value='Remove "- Copy" suffix when copying and pasting files/folders'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule RegPath='\NamingTemplates' ValueName='CopyNameTemplate' On='%s' ValueKind='REG_SZ'/>
       <Rule RegPath='HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\NamingTemplates' ValueName='CopyNameTemplate' On='%s' ValueKind='REG_SZ'/>
     </Item>
     <Item>
       <Text Value='文件(夹) 加密 解密'/>
+      <Text Value='Encrypt / decrypt files/folders'>
+        <Culture>en-US</Culture>
+      </Text>
       <Tip Value='当前账户加密后的文件需解密后才能在其他账户中打开'/>
+      <Tip Value='Files encrypted by the current account must be decrypted before they can be opened under other accounts'>
+        <Culture>en-US</Culture>
+      </Tip>
       <Rule RegPath='\Advanced' ValueName='EncryptionContextMenu' On='1'/>
       <Rule RegPath='HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' ValueName='EncryptionContextMenu' On='1'/>
     </Item>
@@ -70,19 +97,31 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     <RegPath>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer</RegPath>
     <Item>
       <Text Value='右键菜单'/>
+      <Text Value='Context menu'>
+        <Culture>en-US</Culture>
+      </Text>
       <RestartExplorer/>
       <Rule ValueName='NoTrayContextMenu' Off='1'/>
       <Rule RegPath='HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer' ValueName='NoTrayContextMenu' Off='1'/>
     </Item>
     <Item>
       <Text Value='任务栏设置 锁定任务栏'/>
+      <Text Value='Taskbar settings / Lock the taskbar'>
+        <Culture>en-US</Culture>
+      </Text>
       <RestartExplorer/>
       <Rule ValueName='TaskbarLockAll' Off='1'/>
       <Rule RegPath='HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer' ValueName='TaskbarLockAll' Off='1'/>
     </Item>
     <Item>
       <Text Value='工具栏'/>
+      <Text Value='Toolbars'>
+        <Culture>en-US</Culture>
+      </Text>
       <Tip Value='禁用后已启用工具栏将被禁用, 请谨慎操作'/>
+      <Tip Value='Disabling this also disables any currently enabled toolbars; proceed with caution'>
+        <Culture>en-US</Culture>
+      </Tip>
       <RestartExplorer/>
       <Rule ValueName='NoToolbarsOnTaskbar' Off='1'/>
       <Rule ValueName='NoCloseDragDropBands' Off='1'/>
@@ -91,13 +130,22 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     </Item>
     <Item>
       <Text Value='固定到任务栏'/>
+      <Text Value='Pin to taskbar'>
+        <Culture>en-US</Culture>
+      </Text>
       <Tip Value='禁用时已固定图标会被隐藏，重新启用会重现&#x000A;文件右键菜单“固定到任务栏”会同时消失&#x000A;且无法拖拽文件到任务栏进行固定'/>
+      <Tip Value='When disabled, pinned icons are hidden and reappear when re-enabled.&#x000A;"Pin to taskbar" disappears from the file context menu,&#x000A;and files cannot be dragged to the taskbar to pin them.'>
+        <Culture>en-US</Culture>
+      </Tip>
       <RestartExplorer/>
       <Rule RegPath='HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer' ValueName='TaskbarNoPinnedList' Off='1'/>
       <Rule RegPath='HKEY_CURRENT_USER\SOFTWARE\Policies\Microsoft\Windows\Explorer' ValueName='TaskbarNoPinnedList' Off='1'/>
     </Item>
     <Item>
       <Text Value='人脉'/>
+      <Text Value='People'>
+        <Culture>en-US</Culture>
+      </Text>
       <RestartExplorer/>
       <OSVersion Compare='&gt;='>10.0.16199</OSVersion>
       <Rule RegPath='HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\People' ValueName='PeopleBand' Off='0'/>
@@ -105,12 +153,18 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     </Item>
     <Item>
       <Text Value='资讯和兴趣'/>
+      <Text Value='News and interests'>
+        <Culture>en-US</Culture>
+      </Text>
       <RestartExplorer/>
       <OSVersion Compare='&gt;='>10.0.19043</OSVersion>
       <Rule RegPath='HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Feeds' ValueName='EnableFeeds' Off='0'/>
     </Item>
     <Item>
       <Text Value='Windows lnk 工作区(Win+W)'/>
+      <Text Value='Windows Ink Workspace (Win+W)'>
+        <Culture>en-US</Culture>
+      </Text>
       <RestartExplorer/>
       <OSVersion Compare='&gt;='>10.0</OSVersion>
       <Rule RegPath='HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsInkWorkspace' ValueName='AllowWindowsInkWorkspace' Off='0'/>
@@ -126,6 +180,9 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     <RegPath>HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer</RegPath>
     <Item>
       <Text Value='程序右键菜单'/>
+      <Text Value='App context menu'>
+        <Culture>en-US</Culture>
+      </Text>
       <RestartExplorer/>
       <OSVersion Compare='&gt;='>10.0.17134</OSVersion>
       <Rule ValueName='DisableContextMenusInStart' Off='1'/>
@@ -133,6 +190,9 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     </Item>
     <Item>
       <Text Value='卸载'/>
+      <Text Value='Uninstall'>
+        <Culture>en-US</Culture>
+      </Text>
       <RestartExplorer/>
       <OSVersion Compare='&gt;='>6.2</OSVersion>
       <Rule ValueName='NoUninstallFromStart' Off='1'/>
@@ -140,6 +200,9 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     </Item>
     <Item>
       <Text Value='以其他用户身份运行'/>
+      <Text Value='Run as different user'>
+        <Culture>en-US</Culture>
+      </Text>
       <RestartExplorer/>
       <OSVersion Compare='&gt;='>10.0</OSVersion>
       <Rule ValueName='ShowRunAsDifferentUserInStart' On='1'/>
@@ -147,6 +210,9 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     </Item>
     <Item>
       <Text Value='磁贴调整大小、布局、固定、卸载'/>
+      <Text Value='Tile resize, layout, pin, uninstall'>
+        <Culture>en-US</Culture>
+      </Text>
       <RestartExplorer/>
       <OSVersion Compare='&gt;='>6.2</OSVersion>
       <Rule RegPath='HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer' ValueName='NoChangeStartMenu' Off='1'/>
@@ -154,18 +220,27 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     </Item>
     <Item>
       <Text Value='最近打开文件跳转列表'/>
+      <Text Value='Recently opened files jump list'>
+        <Culture>en-US</Culture>
+      </Text>
       <OSVersion Compare='&gt;='>10.0</OSVersion>
       <Rule RegPath='HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' ValueName='Start_TrackDocs' Off='0'/>
       <Rule RegPath='HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' ValueName='Start_TrackDocs' Off='0'/>
     </Item>
     <Item>
       <Text Value='最近打开文件跳转列表数量限制'/>
+      <Text Value='Recently opened files jump list item limit'>
+        <Culture>en-US</Culture>
+      </Text>
       <IsNumberItem/>
       <OSVersion Compare='&gt;='>10.0</OSVersion>
       <Rule RegPath='HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' ValueName='JumpListItems_Maximum' Max='60' Min='0' Default='13'/>
     </Item>
     <Item>
       <Text Value='开始按钮右键菜单(Win+X) 命令提示符 替换为 PowerShell'/>
+      <Text Value='Replace Command Prompt with PowerShell in Start button context menu (Win+X)'>
+        <Culture>en-US</Culture>
+      </Text>
       <RestartExplorer/>
       <OSVersion Compare='&gt;='>10.0</OSVersion>
       <Rule RegPath='HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' ValueName='DontUsePowerShellOnWinX' Off='1'/>
@@ -492,14 +567,23 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     <RegPath>HKEY_CURRENT_USER\SOFTWARE\7-zip</RegPath>
     <Item>
       <Text Value='层叠右键菜单'/>
+      <Text Value='Cascaded context menu'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule RegPath='\Options' ValueName='CascadedMenu' On='1' Off='0'/>
     </Item>
     <Item>
       <Text Value='右键菜单显示图标'/>
+      <Text Value='Show icons in context menu'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule RegPath='\Options' ValueName='MenuIcons' On='1' Off='0'/>
     </Item>
     <Item>
       <Text Value='排除重复的根文件夹'/>
+      <Text Value='Eliminate duplicate root folders'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule RegPath='\Options' ValueName='ElimDupExtract' On='1' Off='0'/>
     </Item>
   </Group>
@@ -510,24 +594,39 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     <RegPath>HKEY_CURRENT_USER\SOFTWARE\NVIDIA Corporation</RegPath>
     <Item>
       <Text Value='显示桌面上下文菜单'/>
+      <Text Value='Show desktop context menu'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule RegPath='\Global\NvCplApi\Policies' ValueName='ContextUIPolicy' On='1' Off='0'/>
     </Item>
     <Item>
       <Text Value='用图形处理器运行'/>
+      <Text Value='Run with graphics processor'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule RegPath='\Global\CoProcManager' ValueName='ShowContextMenu' On='1' Off='0'/>
     </Item>
     <Item>
       <Text Value='显示托盘图标'/>
+      <Text Value='Show tray icon'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule RegPath='\Global\CoProcManager' ValueName='ShowTrayIcon' On='1' Off='0'/>
     </Item>
   </Group>
 
   <Group>
     <Text Value='ACD看图'/>
+    <Text Value='ACDSee Viewer'>
+      <Culture>en-US</Culture>
+    </Text>
     <Guid>c2396f1e-4ba2-4b7d-857a-f764761c012b</Guid>
     <RegPath>HKEY_CURRENT_USER\SOFTWARE\acdkantu</RegPath>
     <Item>
       <Text Value='显示桌面右键菜单'/>
+      <Text Value='Show desktop context menu'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule ValueName='menu' On='1' Off='0' ValueKind='REG_SZ'/>
     </Item>
   </Group>
@@ -538,11 +637,17 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     <RegPath>HKEY_CLASSES_ROOT\CLSID\{b298d29a-a6ed-11de-ba8c-a68e55d89593}</RegPath>
     <Item>
       <Text Value='菜单显示文本'/>
+      <Text Value='Menu display text'>
+        <Culture>en-US</Culture>
+      </Text>
       <IsStringItem/>
       <Rule RegPath='\Settings' ValueName='Title'/>
     </Item>
     <Item>
       <Text Value='显示菜单图标'/>
+      <Text Value='Show menu icon'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule RegPath='\Settings' ValueName='ShowIcon' On='1' Off='0'/>
     </Item>
   </Group>
@@ -554,44 +659,74 @@ ValueKind为键值类型，默认键值类型ValueKind为REG_DWORD，为默认�
     <IsIniGroup/>
     <Item>
       <Text Value='层叠右键菜单'/>
+      <Text Value='Cascaded context menu'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule Section='General' KeyName='CascadedMenu' On='1' Off='0'/>
     </Item>
     <Item>
       <Text Value='智慧右键菜单'/>
+      <Text Value='Smart context menu'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule Section='General' KeyName='CoolMenu' On='1' Off='0'/>
     </Item>
     <Item>
       <Text Value='解压完成后打开目标文件夹'/>
+      <Text Value='Open target folder after extraction'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule Section='Profile.Extract.0' KeyName='OpenAfterExtract' On='1' Off='0'/>
     </Item>
     <Item>
       <Text Value='解压完成后删除源文件'/>
+      <Text Value='Delete source file after extraction'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule Section='Profile.Extract.0' KeyName='DeleteSource' On='1' Off='0'/>
     </Item>
     <Item>
       <Text Value='一键解压完成后自动关闭360压缩'/>
+      <Text Value='Automatically close 360zip after one-click extraction'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule Section='General' KeyName='WiseExtract' On='1' Off='0'/>
     </Item>
   </Group>
 
   <Group>
     <Text Value='WPS云文档'/>
+    <Text Value='WPS Cloud Docs'>
+      <Culture>en-US</Culture>
+    </Text>
     <Guid>67f4d210-bfc2-4add-9a2a-c9b9e1f42c4f</Guid>
     <RegPath>HKEY_CURRENT_USER\SOFTWARE\Kingsoft\WPSCloud</RegPath>
     <Item>
       <Text Value='上传到"WPS云文档"'/>
+      <Text Value='Upload to "WPS Cloud Docs"'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule ValueName='uploadFile' On='true' Off='false' ValueKind='REG_SZ'/>
     </Item>
     <Item>
       <Text Value='发送到"WPS云文档传输助手"'/>
+      <Text Value='Send to "WPS Cloud Docs Transfer Assistant"'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule ValueName='fileTransfer' On='true' Off='false' ValueKind='REG_SZ'/>
     </Item>
     <Item>
       <Text Value='通过"WPS云文档"分享和协作'/>
+      <Text Value='Share and collaborate via "WPS Cloud Docs"'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule ValueName='shareFile' On='true' Off='false' ValueKind='REG_SZ'/>
     </Item>
     <Item>
       <Text Value='同步桌面所有文件'/>
+      <Text Value='Sync all desktop files'>
+        <Culture>en-US</Culture>
+      </Text>
       <Rule ValueName='DesktopSync' On='true' Off='false' ValueKind='REG_SZ'/>
     </Item>
   </Group>

--- a/ContextMenuManager/Properties/Resources/Texts/GuidInfosDic.ini
+++ b/ContextMenuManager/Properties/Resources/Texts/GuidInfosDic.ini
@@ -81,6 +81,7 @@ ResText = @shell32.dll,-5376
 Icon = imageres.dll,-5340
 [3dad6c5d-2167-4cae-9914-f99e41c12cfa]
 Text = 包含到库中(&I)
+en-US-Text = &Include in library
 pt-BR-Text = &Incluir na bibioteca
 Icon = imageres.dll,-1001
 [d969a300-e7ff-11d0-a93b-00a0c90f2719]
@@ -89,6 +90,7 @@ Icon = imageres.dll,-5307
 [a470f8cf-a1e8-4f65-8335-227475aa5c46]
 ResText = @ipsecsnp.dll,-100
 Text = 加密(&Y)
+en-US-Text = Encr&ypt
 pt-BR-Text = &criptografar
 Icon = imageres.dll,-59
 [1d27f844-3a1f-4410-85ac-14651078412d]
@@ -113,6 +115,7 @@ ResText = @shell32.dll,-12560
 Icon = imageres.dll,-30
 [59099400-57ff-11ce-bd94-0020af85b590]
 Text = 复制磁盘(&Y)...
+en-US-Text = Cop&y Disc...
 [d6791a63-e7e2-4fee-bf52-5ded8e86e9b8]
 ResText = @wpdshext.dll,-511
 [0af96ede-aebf-41ed-a1c8-cf7a685505b6]
@@ -122,6 +125,7 @@ Icon = imageres.dll,-5359
 ResText = @twext.dll,-1037
 [6b9228da-9c15-419e-856c-19e768a13bdc]
 Text = Windows 小工具
+en-US-Text = Windows Gadget
 [85bbd920-42a0-1069-a2e4-08002b30309d]
 ResText = @shell32.dll,-22978
 [1a184871-359e-4f67-aad9-5b9905d62232]
@@ -138,14 +142,17 @@ ResText = @msimsg.dll,-38
 [a929c4ce-fd36-4270-b4f5-34ecac5bd63c]
 ResText = @nv3dappshextr.dll,-103
 Text = 用图形处理器运行
+en-US-Text = Run with graphics processor
 Icon = nvcpl.dll
 [e97dec16-a50d-49bb-ae24-cf682282e08d]
 ResText = @nv3dappshextr.dll,-109
 Text = 更改 OpenGL 渲染 GPU...
+en-US-Text = Change OpenGL rendering GPU...
 Icon = nvcpl.dll
 [3d1975af-48c6-4f8e-a182-be0e08fa86a9]
 ResText = @nvsvcr.dll,-4530
 Text = NVIDIA 控制面板
+en-US-Text = NVIDIA Control Panel
 Icon = nvcpl.dll
 [9b5f5829-a529-4b12-814a-e81bcb8d93fc]
 Text = 英特尔® 显卡设置
@@ -175,52 +182,69 @@ Text = 7-zip
 Icon = .\7zG.exe
 [b1832224-9f22-4965-a6e8-e6a6e3c4fdf7]
 Text = 52好压
+en-US-Text = 52 Haozip
 Icon = .\kzip_main.exe
 [5fed836a-c96c-4d88-a91e-f63f07726585]
 Text = 2345好压
+en-US-Text = 2345 Haozip
 Icon = .\HaoZip.exe
 [6adf19e3-77a3-4395-adb4-9fd7d351eb3e]
 Text = 快压
+en-US-Text = KuaiZip
 [903d855a-d671-4a8e-a592-9168755917db]
 Text = 快压
+en-US-Text = KuaiZip
 [6adf19e3-77a3-4395-adb4-9fd7d351eb3e]
 Text = 快压
+en-US-Text = KuaiZip
 [903d855a-d671-4a8e-a592-9168755917db]
 Text = 快压
+en-US-Text = KuaiZip
 [e0d79304-84be-11ce-9641-444553540000]
 Text = WinZip
 Icon = .\WzPreloader.exe
 [acf03765-1658-485f-9615-fe03c372fb8c]
 Text = 微压
+en-US-Text = Weiya
 [dd847e93-86df-4d75-a421-46d29228f6da]
 Text = 极光压缩
+en-US-Text = Aurora Compress
 Icon = .\plFM.exe
 [5e3b6ea4-de96-464f-bb86-5587969f4c62]
 Text = 万能压缩
+en-US-Text = All-in-one Compress
 [9175e343-1c41-4490-b178-14f36504f07e]
 Text = 160压缩
+en-US-Text = 160 Compress
 Icon = .\160zip.exe
 [5e3ca55c-d9f3-4d1c-8b94-ad192b0f7c16]
 Text = 速压
+en-US-Text = SuYa
 Icon = .\Suzip.exe
 [02e77c8d-2798-441e-8e6d-0c2ed9fe206e]
 Text = 简压缩
+en-US-Text = Jian Compress
 Icon = .\SimpleZip.exe
 [5c551008-a347-4db3-af48-014076fd2b46]
 Text = 极速压缩
+en-US-Text = Speed Compress
 Icon = .\JsZip.exe
 [0a4861a5-448a-48b4-812a-cf71a07a674f]
 Text = 6789压缩
+en-US-Text = 6789 Compress
 [7522b611-f22b-4f24-9ce4-3ecbba85c126]
 Text = CoffeeZip
 [aa7f8063-f898-44d0-b147-8a6e9891e32e]
 Text = 布丁压缩
+en-US-Text = Pudding Compress
 Icon = .\PDZip.exe
 [9b8dff9d-0cb2-4100-8f21-c6dd6ce01141]
 Text = 布丁压缩
+en-US-Text = Pudding Compress
 Icon = .\PDZip.exe
 [d81a0ed9-6c47-417b-b298-4ebd813cabd0]
 Text = 极客压缩
+en-US-Text = Geek Compress
 Icon = .\GeekZip.exe
 [e677c7ad-2b66-4539-aa29-3771a1cfeda9]
 Text = jZip
@@ -264,45 +288,61 @@ Text = 使用火绒安全粉碎文件
 en-US-Text = Shred with Huorong Internet Security
 [63332668-8ce1-445d-a5ee-25929176714e]
 Text = 扫描病毒(电脑管家)
+en-US-Text = Scan for viruses (PC Manager)
 [754df2ce-51e8-4895-b53c-6381418b84ae]
 Text = 文件粉碎(电脑管家)
+en-US-Text = Shred file (PC Manager)
 [cbdecef7-7a29-4cbf-a009-2673d82c7bf9]
 Text = 强力卸载(电脑管家)
+en-US-Text = Force uninstall (PC Manager)
 Icon = .\QQPCSoftMgr.exe
 [c5617f6a-39bb-436d-91cf-61c1b45dd688]
 Text = 深度加速(管家小火箭)
+en-US-Text = Deep boost (Little Rocket)
 [b7667919-3765-4815-a66d-98a09be662d6]
 Text = 清理垃圾(电脑管家)
+en-US-Text = Clean junk (PC Manager)
 [086f171d-5ed1-4ed2-b736-cff3ad6a128e]
 Text = 使用 360杀毒 扫描
+en-US-Text = Scan with 360 Antivirus
 Icon = .\msdev.exe
 [7c0f6d57-e799-4c8a-a319-8e2b4d724cf0]
 Text = 360安全卫士
+en-US-Text = 360 Security Guard
 Icon = ..\360Safe.exe
 [5e19c0ce-c02c-46c2-98c3-a2e12ede0e17]
 Text = 360强力卸载 && 桌面助手
+en-US-Text = 360 Force Uninstall && Desktop Assistant
 Icon = .\SoftMgr.exe
 [c4f75db1-b9f4-425a-9f5b-778911bcf176]
 Text = 2345扫描病毒 && 强力删除
+en-US-Text = 2345 Scan for viruses && Force delete
 Icon = .\2345MPCSafe.exe
 [6b3ba4a8-ec7e-4714-9ecf-eb33995b3384]
 Text = 使用2345软件管家卸载软件
+en-US-Text = Uninstall with 2345 Software Manager
 Icon = ..\..\2345SoftMgr.exe
 [ddea5705-1bb0-4c03-ac1e-8ff9716a0d51]
 Text = 金山毒霸(64位)
+en-US-Text = Kingsoft Antivirus (64-bit)
 Icon = .\kismain.exe
 [d21d88e8-4123-48ba-b0b1-3fdbe4ae5fa4]
 Text = 金山毒霸(32位)
+en-US-Text = Kingsoft Antivirus (32-bit)
 Icon = .\kismain.exe
 [367f6ae2-6809-4bed-b09b-228893fb33dd]
 Text = 金山毒霸
+en-US-Text = Kingsoft Antivirus
 Icon = .\kismain.exe
 [758c684b-4d10-4bc1-90da-6bebf0b4e0b4]
 Text = 使用联想电脑管家进行扫描
+en-US-Text = Scan with Lenovo PC Manager
 [c97c3e31-2af4-4651-9e93-ede827605a23]
 Text = 强力卸载此软件(联想电脑管家)
+en-US-Text = Force uninstall this software (Lenovo PC Manager)
 [c49499ac-dc25-478b-b903-e005012b3dd1]
 Text = 使用智量扫描
+en-US-Text = Scan with Zhiliang
 Icon = .\WiseVector.exe
 [cca9efd3-29ed-430a-ba6d-e6bbff0a60c2]
 Text = McAfee
@@ -312,9 +352,11 @@ Text = Avast
 Icon = ..\AvastUI.exe
 [45ac2688-0253-4ed8-97de-b5370fa7d48a]
 Text = 使用 Avira 扫描所选文件
+en-US-Text = Scan selected files with Avira
 Icon = ..\Launcher\Avira.Systray.exe
 [9b9f6e01-a5cf-4269-b245-cff66a7daebd]
 Text = 卡巴斯基
+en-US-Text = Kaspersky
 [57ce581a-0cb6-4266-9ca0-19364c90a0b3]
 Text = Malwarebytes
 [f7caa2a1-67a2-44bb-b20f-202fd8eb1dab]
@@ -322,11 +364,13 @@ Text = Norton 360
 Icon = .\uiStub.exe
 [fad61b3d-699d-49b2-be16-7f82cb4c59ca]
 Text = Norton文件智能分析
+en-US-Text = Norton Insight
 Icon = .\uiStub.exe
 [e8215bea-3290-4c73-964b-75502b9b41b2]
 Text = Norton File Shredder
 [1c7593cb-c1cc-4ba7-be52-8eea47f9cb1d]
 Text = 使用瑞星杀毒
+en-US-Text = Scan with Rising Antivirus
 [0bb81440-5f42-4480-a5f7-770a6f439fc8]
 Text = IObit Malware Fighter
 Icon = *,3
@@ -336,34 +380,44 @@ Text = ESET Endpoint Antivirus
 ;----------------传输------------------
 [53d2405c-48ab-4c8a-8f59-ce0610f13bbc]
 Text = 通过QQ发送到
+en-US-Text = Send via QQ to
 [cb3d0f55-bc2c-4c1a-85ed-23ed75b5106b]
 Text = OneDrive
 Icon = ..\..\OneDrive.exe
 [6d85624f-305a-491d-8848-c1927aa0d790]
 Text = 上传到百度网盘
+en-US-Text = Upload to Baidu NetDisk
 Icon = .\BaiduNetdisk.exe
 [2008caf4-a5c1-4037-99a8-699e4d01456d]
 Text = 天翼云盘
+en-US-Text = Tianyi Cloud Drive
 Icon = .\eCloud.exe
 [1d39a523-4df5-4562-8fff-08c740632f4f]
 Text = 360云盘
+en-US-Text = 360 Cloud Drive
 Icon = .\360WangPan.exe
 [eee949eb-c9ed-4967-98b0-ed4e543befa5]
 Text = 115网盘
+en-US-Text = 115 Cloud Drive
 Icon = ..\115chrome.exe
 [171b6b53-17b1-40b7-afb2-a415b2b40401]
 Text = 上传到腾讯微云
+en-US-Text = Upload to Tencent Weiyun
 Icon = ..\..\..\..\..\..\..\WeiyunApp.exe
 [5d652b62-b702-496a-92bc-92c308251fea]
 Text = 坚果云
+en-US-Text = Nutstore
 Icon = *,3
 [67f4d210-bfc2-4add-9a2a-c9b9e1f42c4f]
 Text = 上传到 “WPS云文档”
+en-US-Text = Upload to “WPS Cloud Docs”
 Icon = ..\..\ksolaunch.exe
 [aa147ffb-0b1f-4bb1-9b1e-8d062b35c145]
 Text = 自动同步文件夹到 “WPS云文档”
+en-US-Text = Automatically sync folder to “WPS Cloud Docs”
 [970a26b5-2b84-4b60-8067-1440c229672d]
 Text = 钉盘
+en-US-Text = DingTalk Drive
 Icon = ..\DingtalkLauncher.exe
 [0229e5e7-09e9-45cf-9228-0228ec7d5f17]
 Text = MEGA
@@ -378,130 +432,168 @@ Text = TortoiseGit
 Icon = .\TortoiseGitProc.exe
 [2a535b11-6cfc-4e85-a75f-0e397b1584cf]
 Text = 通过网易邮箱大师发送
+en-US-Text = Send via NetEase Mail Master
 Icon = ..\mailmaster.exe
 [9557f42f-bd61-4e26-9752-33a8a20fc9f9]
 Text = 分享文件(华为电脑管家)
+en-US-Text = Share file (Huawei PC Manager)
 Icon = .\PCManager.exe
 [c3db4192-4c22-428f-8c12-cf9cfabbdd17]
 Text = 通过AirDroid发送到我的设备
+en-US-Text = Send to my device via AirDroid
 [0b488c12-e68e-44d7-9259-fb8e5df8bb27]
 Text = 内网通
+en-US-Text = NetTalk
 Icon = .\ShiYeLine.exe
 [256ef94c-697d-4986-b99b-9d3b15d79b49]
 Text = Infinit
 [a97a01b0-3b66-4336-bc9b-168e64bfb296]
 Text = 广讯通发送文件
+en-US-Text = GXT send file
 Icon = .\GXT.exe
 [41b3b91f-d6b3-3430-bb86-a143f85353ca]
 Text = Huawei Share
 [1bca9901-05c3-4d01-8ad4-78da2eac9b3f]
 Text = 使用小米互传发送
+en-US-Text = Send with Mi Share
 Icon = .\FixServiceTool.exe
 
 ;----------------PDF------------------
 [9c5397bb-07be-4e38-98ba-395f94045091]
 Text = 福昕PDF编辑器
+en-US-Text = Foxit PDF Editor
 Icon = ..\FoxitPhantom.exe
 [27be7b9d-935f-325c-9a05-63557d69f4f9]
 Text = 万兴PDF专家
+en-US-Text = Wondershare PDFelement
 Icon = ..\PDFExpert.exe
 [a6595cd1-bf77-430a-a452-18696685f7c7]
 Text = Adobe Acrobat
 Icon = ..\Acrobat\Acrobat.exe
 [d25b2cab-8a9a-4517-a9b2-cb5f68a5a802]
 Text = 转换为Adobe PDF(&B)
+en-US-Text = Convert to Adobe PD&F
 [1ecda7bf-4dfa-41d8-9380-1a27b26cfc41]
 Text = 使用WPS PDF编辑
+en-US-Text = Edit with WPS PDF
 Icon = ..\..\wpspdf.exe
 [e3ed4700-22d4-41b6-8144-e3f5f1ac5153]
 Text = 使用WPS PDF编辑
+en-US-Text = Edit with WPS PDF
 Icon = ..\..\wpspdf.exe
 [af1d7d2f-6ae8-4baa-abfa-738201f4871c]
 Text = WPS Office PDF
 Icon = .\wpspdf.exe
 [b4e15cd0-f916-4c8e-830a-15e3e9d01a1b]
 Text = 迅读PDF大师 合并、拆分、转换
+en-US-Text = Xunread PDF Master - Merge, split, convert
 Icon = .\MasterPDF.exe
 [19a73c67-f0b8-4a28-8c33-9d4eddd6fcbc]
 Text = 云上PDF
+en-US-Text = YunShang PDF
 Icon = .\iPDF.exe
 [29424e92-60a1-40c0-bf79-1b8472dde706]
 Text = 使用PDF猫编辑器打开
+en-US-Text = Open with PDFmate Editor
 Icon = .\M_pdfEdit.exe
 [29424e91-60a1-40c0-bf79-1b8472dde606]
 Text = 使用转转大师PDF编辑器打开
+en-US-Text = Open with ZhuanzhuanMaster PDF Editor
 Icon = .\ZPDFEdit.exe
 [098a124a-aa1c-38c8-a65e-d1199a14516a]
 Text = Convert to...(万兴PDF专家)
+en-US-Text = Convert to... (Wondershare PDFelement)
 [fb074836-8286-4089-84dc-f504e9ef621c]
 Text = ABBYY FineReader
 Icon = ..\FineUpdate.exe
 [d16adfe3-66c5-4df5-9978-87de0c687e85]
 Text = 嗨格式PDF转换器
+en-US-Text = HiPDF Converter
 Icon = .\HiPdfConvert.exe
 [2acd35ab-f74a-4c20-aa9b-2de80081626d]
 Text = PDF-XChange Editor
 Icon = ..\PDF Editor\PDFXEdit.exe
 [6c405cec-8624-4fef-b3ba-9d4e5a8f58b5]
 Text = 迅捷PDF转换器
+en-US-Text = Xunjie PDF Converter
 Icon = .\pdfconverter.exe
 
 ;--------------影音图像----------------
 [ffe2a43c-56b9-4bf5-9a79-cc6d4285608a]
 ResText = @*,-3050
 Text = 向右、向左旋转(&T)​​
+en-US-Text = Ro&tate right, rotate left​​
 [e598560b-28d5-46aa-a14a-8a3bea34b576]
 Text = 幻灯片放映
+en-US-Text = Slide Show
 [8a734961-c4aa-4741-ac1e-791acebf5b39]
 Text = 联机购买音乐
+en-US-Text = Buy music online
 [f1b9284f-e9dc-4e68-9d7e-42362a59f0fd]
 Text = 添加到“Windows Media Player”列表(&W)
+en-US-Text = Add to “&Windows Media Player” list
 [ce3fb1d1-02ae-4a5f-a6e9-d9f1b4073e6c]
 Text = 使用“Windows Media Player”播放(&P)
+en-US-Text = &Play with “Windows Media Player”
 [7d4734e6-047e-41e2-aeaa-e763b4739dc4]
 Text = 使用 Media Player 播放(&P)
+en-US-Text = &Play with Media Player
 [9b6d38f3-8ef4-48a5-ad30-ffffffffffff]
 Text = Honeyview
 Icon = .\Honeyview.exe
 [c2396f1e-4ba2-4b7d-857a-f764761c012b]
 Text = ACD看图
+en-US-Text = ACDSee Viewer
 Icon = .\AcdKantu.exe
 [83a97a48-f5d7-4d12-8ba3-5263a016d936]
 Text = 使用光影4.0编辑
+en-US-Text = Edit with Neo Imaging 4.0
 [8f556da3-987d-47b0-aa88-eb8d52fe1b9a]
 Text = 迅雷播放组件
+en-US-Text = Thunder Player Component
 Icon = ..\Program\XMP\XMP.exe
 [5cd76c57-6893-478a-b776-47e7c82504be]
 Text = 爱奇艺万能联播
+en-US-Text = iQiyi Universal Player
 Icon = .\GeePlayer.exe
 [a3888921-cfd3-4a6b-89bf-08e6b95716e8]
 Text = 图片工厂(&F)
+en-US-Text = Picture &Factory
 [51b4d7e5-7568-4234-b4bb-47fb3c016a69]
 ResText = @*,-101
 Text = 调整图片大小(PowerToys)
+en-US-Text = Resize images (PowerToys)
 [5c6a637c-9780-4d0f-a379-4732edcce7c3]
 Text = 网易云音乐
+en-US-Text = NetEase Cloud Music
 [1f77b17b-f531-44db-aca4-76abb5010a28]
 Text = AIMP
 Icon = ..\AIMP.exe
 [8e7861bb-3a13-40a1-af25-633458757201]
 Text = QQ影音
+en-US-Text = QQ Player
 [7a1884a3-f647-49be-b93c-8ffaf4a1f1bf]
 Text = 使用PP视频播放
+en-US-Text = Play with PPTV
 [8f556da3-987d-47b0-aa88-eb8d52fe1b99]
 Text = 迅雷影音
+en-US-Text = Thunder Video
 Icon = ..\..\Program\APlayer.exe
 [4d2fba8d-621b-4447-af6d-5794f479c4a5]
 Text = 爱奇艺看图
+en-US-Text = iQiyi Image Viewer
 Icon = ..\QyImg.exe
 [4a34b3e3-f50e-4ff6-8979-7e4176466ff2]
 Text = SageThumbs
 [d149b06b-bc31-4425-b5bb-0e04308982ae]
 Text = 用百图秀打开
+en-US-Text = Open with Baitushow
 [5add1a3c-29e2-4d18-b79a-c56e1df5486c]
 Text = 百图秀
+en-US-Text = Baitushow
 [1bb8f8e1-6492-4ec9-ac40-9ad0f5c01fa2]
 Text = 鲨鱼看图
+en-US-Text = Shark Image Viewer
 Icon = .\SharkElevate.exe
 [a2cf4243-6525-4764-b3f5-2fcde2f47989]
 Text = MPC-BE
@@ -510,20 +602,26 @@ Icon = .\unins000.exe
 ;----------------美化------------------
 [cf444751-60fc-48b8-ac0f-363063eb2a9e]
 Text = 开启桌面整理(电脑管家)
+en-US-Text = Enable desktop organizer (PC Manager)
 [b3a2f1a4-10a2-410c-9c19-622b621c61d0]
 Text = 换壁纸(小鸟壁纸)
+en-US-Text = Change wallpaper (Xiaoniao Wallpaper)
 [3b7162fb-4389-40c8-83a5-da10d491ec66]
 Text = 映射此文件夹到桌面(小智桌面)
+en-US-Text = Map this folder to desktop (Xiaozhi Desktop)
 Icon = .\XZDesktop.exe
 [96babf4f-7c38-4885-b407-3800f461669b]
 Text = 打开火萤视频桌面
+en-US-Text = Open Huoying Video Desktop
 Icon = ..\..\HYVideoDesktop.exe
 [c3c76829-1d8b-49a2-afb4-196c443f1b0b]
 Text = 人工桌面
+en-US-Text = Artificial Desktop
 Icon = .\N0vaDesktop.exe
 [a2a9545d-a0c2-42b4-9708-a0b2badd77c9]
 ResText = @*,-5381
 Text = 附到「开始」菜单(&U)(StartIsBack)
+en-US-Text = Pin to 「Start」 men&u (StartIsBack)
 Icon = .\StartIsBackCfg.exe
 [6a451c0a-9597-4915-bcce-6e859bc996b2]
 Text = Pin to Start (Start10)
@@ -533,18 +631,23 @@ Text = Start Menu 8
 Icon = *,2
 [07451604-fbe4-4475-9dd6-261b7b619417]
 Text = 电脑管家经典开始菜单
+en-US-Text = PC Manager Classic Start Menu
 Icon = .\QMStart.exe
 [2d5ad9eb-31bc-48f7-a438-28f363632c73]
 Text = 开启布丁桌面
+en-US-Text = Enable Pudding Desktop
 Icon = .\PDLanuncher.exe
 [b5e436bc-642a-4bf6-b725-26038af26e89]
 Text = 开启桌面整理(元气、猎豹轻桌面)
+en-US-Text = Enable desktop organizer (Yuanqi, Cheetah Light Desktop)
 Icon = .\kdesk.exe
 [5f8d079b-8ce6-4f58-bf10-55c1b68d88f3]
 Text = 选择颜色设置
+en-US-Text = Choose color settings
 Icon = .\ChromaTune.exe
 [6c125022-639d-43cc-9f3d-647e6cc69ef1]
 Text = 右键菜单背景插件(ContextBG)
+en-US-Text = Context menu background plugin (ContextBG)
 
 ;--------------文件处理----------------
 [b298d29a-a6ed-11de-ba8c-a68e55d89593]
@@ -563,6 +666,7 @@ Text = PSPad Editor
 Icon = .\PSPad.exe
 [a3777921-cfd3-4a6b-89bf-08e6b95716e8]
 Text = 格式工厂(&F)
+en-US-Text = Format &Factory
 Icon = .\FormatFactory.exe
 [af9b72b5-f4e4-44b0-a3d9-b55b748efe90]
 Text = File Converter
@@ -572,12 +676,14 @@ Text = Unlocker
 Icon = .\Unlocker.exe
 [0bb27cda-7029-4c0e-9c56-d922b229f0eb]
 Text = 解除文件锁定(LockHunter)
+en-US-Text = Unlock file (LockHunter)
 Icon = .\LockHunter.exe
 [410bf280-86ef-4e0f-8279-ec5848546ad3]
 Text = IObit Unlocker
 Icon = .\IObitUnlocker.exe
 [836ab26c-2de4-41d3-ac24-4c6c2699b960]
 Text = 强力卸载(IObit Uninstaller)
+en-US-Text = Force uninstall (IObit Uninstaller)
 [2803063f-4b8d-4dc6-8874-d1802487fe2d]
 Text = Advanced SystemCare
 Icon = *,3
@@ -599,6 +705,7 @@ ResText = @*,-101
 Text = PowerRename(&W)
 [2e7a2c6c-b938-40a4-ba1c-c7ec982dc202]
 Text = 发布DWF
+en-US-Text = Publish DWF
 Icon = .\AcLauncher.exe
 [57fa2d12-d22d-490a-805a-5cb48e84f12a]
 Text = Beyond Compare
@@ -610,6 +717,7 @@ Icon = .\uc.exe
 Text = FileLocator Pro
 [00000000-0000-0000-0000-000000000012]
 Text = 显示隐藏文件+扩展名
+en-US-Text = Show hidden files + extensions
 [c1b2c38f-3dca-4e3d-bc34-d5b87b636543]
 Text = FileMenu Tools
 [189f1e63-33a7-404b-b2f6-8c76a452cc54]
@@ -629,25 +737,30 @@ Text = Locale Emulator
 Icon = .\LEGUI.exe
 [0a479751-02bc-11d3-a855-0004ac2568aa]
 Text = NTFS文件连接扩展配置工具
+en-US-Text = NTFS Link Extension configuration tool
 Icon = .\LSEConfig.exe
 [fdf253ac-1724-4853-be34-c2dbc18fb5ca]
 Text = Copywhiz
 Icon = .\Copywhiz.exe
 [6c467336-8281-4e60-8204-430ced96822d]
 Text = 共享文件夹同步
+en-US-Text = Shared folder sync
 [6fa85dad-ac32-4d74-9cba-6a1c038f9a56]
 Text = 文档加密/解密
+en-US-Text = Document encrypt / decrypt
 [ef479680-ea35-4ea9-b093-7114f3e3e0da]
 Text = Directory Lister
 Icon = .\DirListerPro.exe
 [8e57c449-7891-49bb-80e5-ddac375f8ac8]
 Text = 使用微表格打开
+en-US-Text = Open with WeTable
 Icon = .\microexcel.exe
 [0d8b46ea-7d35-4921-b88c-7e2b1e2d80f0]
 Text = WPS Office
 Icon = ..\..\wpsoffice.exe
 [53506455-e799-443f-addb-891ca6efc928]
 Text = 扫描游戏到快吧游戏
+en-US-Text = Scan games to Kuai8 Games
 [2a118eb5-5797-4f5e-8b3d-f4ecba3c98e4]
 Text = Adobe Core Sync Extension
 
@@ -656,6 +769,7 @@ Text = Adobe Core Sync Extension
 UwpName = Microsoft.SkypeApp
 ResText = @*,-101
 Text = 使用 Skype 共享
+en-US-Text = Share with Skype
 Icon = .\Skype.exe
 [9f156763-7844-4dc4-b2b1-901f640f5155]
 UwpName = Microsoft.WindowsTerminal

--- a/languages/en-US.ini
+++ b/languages/en-US.ini
@@ -211,6 +211,7 @@ CommandCannotBeEmpty = Menu command cannot be empty!
 StringParsingFailed = Localized string parsing failed!
 TextLengthCannotExceed80 = Menu text you entered is too long. The length cannot exceed 80 characters!
 ConfirmDeleteBackupPermanently = Are you sure you want to permanently delete this item? \r\n Be careful, this operation cannot be undone!
+ConfirmDeletePermanently = Are you sure you want to permanently delete this item? \r\n Be careful, this operation cannot be undone!
 DeleteButCanRestore = Are you sure you want to delete the registry item of this menu? \r\n Since automatic backup is enabled (enabled by default),\r\n it can be restored from the backup folder after deletion.
 ConfirmDeleteReference = Are you sure you want to delete this item? \r\n Be careful, all items referencing this item will become invalid!
 ConfirmDelete = Are you sure you want to delete this item?

--- a/languages/zh-CN.ini
+++ b/languages/zh-CN.ini
@@ -215,6 +215,7 @@ CommandCannotBeEmpty = 菜单命令不能为空！
 StringParsingFailed = 本地化字符串解析失败！
 TextLengthCannotExceed80 = 菜单文本过长，长度不允许超过80！
 ConfirmDeleteBackupPermanently = 确认是否永久删除此项？\r\n此操作无法还原，请谨慎操作！
+ConfirmDeletePermanently = 确认是否永久删除此项？\r\n此操作无法还原，请谨慎操作！
 DeleteButCanRestore = 确认删除此菜单的注册表项目？\r\n由于启用了自动备份（默认启用），\r\n删除后可在备份文件夹中还原。
 ConfirmDeleteReference = 确认是否移除对该项目的引用？
 ConfirmDelete = 确认是否删除该项？


### PR DESCRIPTION
## Summary
Fills in missing English translations so the UI stops showing Chinese strings when the language is set to English, and adds the `ConfirmDeletePermanently` key that was already referenced in code but missing from three dictionaries.

### Changes
- **`DetailedEditDic.xml`** — add `en-US` `<Text>` / `<Tip>` siblings for Windows tweaks (classic compact menu, MenuDropAlignment, Shell invoke limit, shortcut/copy name suffixes, file encryption), taskbar/Win+X items, 7-zip options, NVIDIA, ACDSee, WPS Cloud Docs, and 360zip groups.
- **`GuidInfosDic.ini`** — add `en-US-Text` entries for many GUID-identified third-party menu items: compression tools (好压, 快压, 微压, 极光, etc.), antivirus (电脑管家, 360, 2345, 金山, Avira, 卡巴斯基, 瑞星…), cloud drives (百度网盘, 天翼, 115, 腾讯微云, 坚果云, WPS云文档, 钉盘), PDF editors (福昕, 万兴, WPS PDF, 嗨格式, 迅捷…), media players (ACD看图, 迅雷, QQ影音, 爱奇艺…), desktop tools, and more.
- **`AppLanguageDic.ini`, `languages/zh-CN.ini`, `languages/en-US.ini`** — add the `ConfirmDeletePermanently` key. It is already used by `ITsiDeleteItem.cs` and defined on `AppString.Message` but was missing from these three dictionaries; `pt-BR`, `zh-TW`, and `tr-TR` already had it.

### Notes
- No code changes; resource files only.
- Chinese strings are preserved as the default; English is added as the localized alternative.
- Some third-party brand names are kept close to their Chinese originals where there is no established English brand (e.g. "Pudding Compress" for 布丁压缩). Happy to adjust if you prefer different wording.