### PR TITLE
Add setting to toggle dimming of inferred menu item icons

### DIFF
--- a/ContextMenuManager/BluePointLilac.Methods/ImageExtension.cs
+++ b/ContextMenuManager/BluePointLilac.Methods/ImageExtension.cs
@@ -20,6 +20,11 @@ namespace ContextMenuManager.Methods
             return bitmap;
         }
 
+        public static Image ToInferredIcon(this Image image, float opacity = 0.5F)
+        {
+            return AppConfig.DimInferredIcons ? image.ToTransparent(opacity) : image;
+        }
+
         public static Image ResizeImage(this Image image, int width, int height)
         {
             //return image.GetThumbnailImage(width, height, null, System.IntPtr.Zero);//质量稍微低一点

--- a/ContextMenuManager/Controls/ShellItem.cs
+++ b/ContextMenuManager/Controls/ShellItem.cs
@@ -52,7 +52,7 @@ namespace ContextMenuManager.Controls
                 if (List != null)
                 {
                     Image = ItemIcon.ToBitmap();
-                    if (!HasIcon) Image = Image.ToTransparent();
+                    if (!HasIcon) Image = Image.ToInferredIcon();
                     BtnSubItems.Visibility = IsMultiItem ? Visibility.Visible : Visibility.Collapsed;
                 }
             }
@@ -291,7 +291,7 @@ namespace ContextMenuManager.Controls
             {
                 if (!TryProtectOpenItem()) return;
                 Registry.SetValue(CommandPath, "", value);
-                if (!HasIcon) Image = ItemIcon.ToBitmap().ToTransparent();
+                if (!HasIcon) Image = ItemIcon.ToBitmap().ToInferredIcon();
             }
         }
 
@@ -478,7 +478,7 @@ namespace ContextMenuManager.Controls
         {
             IconLocation = null;
             HasLUAShield = false;
-            Image = Image.ToTransparent();
+            Image = Image.ToInferredIcon();
         }
 
         private void UseShieldIcon()
@@ -494,7 +494,7 @@ namespace ContextMenuManager.Controls
                 }
                 else
                 {
-                    Image = Image.ToTransparent();
+                    Image = Image.ToInferredIcon();
                 }
             }
         }

--- a/ContextMenuManager/Methods/AppConfig.cs
+++ b/ContextMenuManager/Methods/AppConfig.cs
@@ -285,6 +285,12 @@ namespace ContextMenuManager.Methods
             set => SetGeneralValue("HideSysStoreItems", value ? 1 : 0);
         }
 
+        public static bool DimInferredIcons
+        {
+            get => GetGeneralValue("DimInferredIcons") != "0";
+            set => SetGeneralValue("DimInferredIcons", value ? 1 : 0);
+        }
+
         public static bool RequestUseGithub
         {
             get

--- a/ContextMenuManager/Methods/AppString.cs
+++ b/ContextMenuManager/Methods/AppString.cs
@@ -378,6 +378,7 @@ namespace ContextMenuManager.Methods
             public static string OpenMoreExplorer { get; set; }
             public static string HideDisabledItems { get; set; }
             public static string HideSysStoreItems { get; set; }
+            public static string DimInferredIcons { get; set; }
             public static string SetPerceivedType { get; set; }
             public static string SetDefaultDropEffect { get; set; }
             public static string TopMost { get; set; }

--- a/ContextMenuManager/Properties/Resources/Texts/AppLanguageDic.ini
+++ b/ContextMenuManager/Properties/Resources/Texts/AppLanguageDic.ini
@@ -324,6 +324,7 @@ CustomEngine = 自定义
 SetCustomEngine = 设置搜索引擎 （以 %s 代替搜索关键词）
 HideDisabledItems = 隐藏已禁用的菜单项目
 HideSysStoreItems = 隐藏公共引用中的系统菜单
+DimInferredIcons = 对推测的图标使用半透明效果
 SetPerceivedType = 设置扩展名为 %s 的文件感知类型为
 SetDefaultDropEffect = 设置文件对象默认拖拽命令为
 TopMost = 使窗口始终在屏幕最上方

--- a/ContextMenuManager/Views/AppSettingView.xaml
+++ b/ContextMenuManager/Views/AppSettingView.xaml
@@ -314,6 +314,27 @@
                             OnContent=""
                             Toggled="HideSysStoreItemsCheckBox_OnChanged" />
                     </Grid>
+
+                    <Separator Margin="0,16,0,16" />
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Margin="0,0,20,0" VerticalAlignment="Center">
+                            <TextBlock x:Name="DimInferredIconsLabel" Style="{StaticResource SettingNameStyle}" />
+                        </StackPanel>
+                        <ui:ToggleSwitch
+                            x:Name="DimInferredIconsCheckBox"
+                            Grid.Column="1"
+                            MinWidth="0"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Center"
+                            OffContent=""
+                            OnContent=""
+                            Toggled="DimInferredIconsCheckBox_OnChanged" />
+                    </Grid>
                 </StackPanel>
             </Border>
         </Grid>

--- a/ContextMenuManager/Views/AppSettingView.xaml.cs
+++ b/ContextMenuManager/Views/AppSettingView.xaml.cs
@@ -40,6 +40,7 @@ namespace ContextMenuManager.Views
             OpenMoreExplorerCheckBox.IsOn = AppConfig.OpenMoreExplorer;
             HideDisabledItemsCheckBox.IsOn = AppConfig.HideDisabledItems;
             HideSysStoreItemsCheckBox.IsOn = AppConfig.HideSysStoreItems;
+            DimInferredIconsCheckBox.IsOn = AppConfig.DimInferredIcons;
 
             var showHideSysStore = WinOsVersion.Current >= WinOsVersion.Win7;
             HideSysStoreRow.Visibility = showHideSysStore ? Visibility.Visible : Visibility.Collapsed;
@@ -109,6 +110,8 @@ namespace ContextMenuManager.Views
             HideDisabledItemsLabel.Text = AppString.Other.HideDisabledItems;
 
             HideSysStoreItemsLabel.Text = AppString.Other.HideSysStoreItems;
+
+            DimInferredIconsLabel.Text = AppString.Other.DimInferredIcons;
 
             LoadDynamicOptions();
         }
@@ -279,6 +282,14 @@ namespace ContextMenuManager.Views
             if (!isLoading)
             {
                 AppConfig.HideSysStoreItems = HideSysStoreItemsCheckBox.IsOn;
+            }
+        }
+
+        private void DimInferredIconsCheckBox_OnChanged(object sender, RoutedEventArgs e)
+        {
+            if (!isLoading)
+            {
+                AppConfig.DimInferredIcons = DimInferredIconsCheckBox.IsOn;
             }
         }
 

--- a/languages/en-US.ini
+++ b/languages/en-US.ini
@@ -328,6 +328,7 @@ CustomEngine = Custom...
 SetCustomEngine = Define search engine (use %s instead of search keywords) 
 HideDisabledItems = Hide disabled items
 HideSysStoreItems = Hide system store items
+DimInferredIcons = Dim icons inferred from the item's command
 SetPerceivedType = Set %s perceived type...
 SetDefaultDropEffect = Set default drop effect
 TopMost = Always on top

--- a/languages/zh-CN.ini
+++ b/languages/zh-CN.ini
@@ -324,6 +324,7 @@ CustomEngine = 自定义
 SetCustomEngine = 设置搜索引擎 （以 %s 代替搜索关键词）
 HideDisabledItems = 隐藏已禁用的菜单项目
 HideSysStoreItems = 隐藏公共引用中的系统菜单
+DimInferredIcons = 对推测的图标使用半透明效果
 SetPerceivedType = 设置扩展名为 %s 的文件感知类型为
 SetDefaultDropEffect = 设置文件对象默认拖拽命令为
 TopMost = 使窗口始终在屏幕最上方


### PR DESCRIPTION
## Summary
- Adds a new `DimInferredIcons` setting (defaults to on, matching current behavior).
- When a menu item's registry entry has no `Icon` value (and no `HasLUAShield`), the app derives an icon from the command's executable / file-type association / a generic blank page and renders it semi-transparent. Users who prefer a uniform look can now turn that dimming off so inferred icons appear at full opacity alongside declared ones.
- Introduces an `Image.ToInferredIcon()` helper that replaces the four `!HasIcon` → `ToTransparent()` call sites in `ShellItem.cs`. The `InvalidItem` placeholder in `ShellSubMenuDialog.cs` is left as-is — its transparency signals a broken menu entry, not an inferred icon.
- Adds the toggle to the settings page and `DimInferredIcons` strings to `AppLanguageDic.ini` (zh-CN default), `zh-CN.ini`, and `en-US.ini`.

## Test plan
- [x] With the setting **on** (default), menu items without an explicit `Icon` registry value still render semi-transparent.
- [x] Toggling the setting **off** makes those items render at full opacity on the next refresh.
- [x] Deleting an icon on an item (context menu → delete icon) respects the setting.
- [x] Toggling `HasLUAShield` off on an item with no `Icon` value respects the setting (note: surfaces a pre-existing refresh bug where the shield image stays until you navigate away — not caused by this PR).