### PR TITLE
Fix dropdown text clipping in non-Chinese locales

### DIFF
--- a/ContextMenuManager/Controls/ShellList.cs
+++ b/ContextMenuManager/Controls/ShellList.cs
@@ -1025,7 +1025,7 @@ namespace ContextMenuManager.Controls
 
             private readonly ComboBox cmbDic = new()
             {
-                Width = 220
+                MinWidth = 220
             };
         }
     }

--- a/ContextMenuManager/Controls/SwitchDicList.cs
+++ b/ContextMenuManager/Controls/SwitchDicList.cs
@@ -34,7 +34,7 @@ namespace ContextMenuManager.Controls
             {
                 cmbDic = new()
                 {
-                    Width = 120
+                    MinWidth = 120
                 };
 
                 Text = AppString.Other.SwitchDictionaries;


### PR DESCRIPTION
## Summary
- Two ComboBoxes (`SwitchDicList` and `ShellList`'s Win11/Win10 menu-style toggle) were created with a fixed `Width` in pixels, sized for short Chinese strings. Longer translations like de-DE "Win10 Klassischer Rechtsklick-Menüstil", pt-BR "Estilo clássico de menu de contexto do Win10", de-DE "Internet-Wörterbuch", and tr-TR "Kullanıcı Sözlükleri" overflowed, and the selection text was clipped.
- Replaces `Width` with `MinWidth` so WPF auto-measures each ComboBox to its widest item. The parent `MyListItem` puts controls in a `GridLength.Auto` column, so the row grows without breaking the title layout. Same pattern is already used in `LanguagesView`, `SelectDialog`, and `BackupDialog`.
- Audited every other ComboBox / dropdown in the codebase: all already use `MinWidth` (or live in star-sized grid cells). Other `Width = N` matches are `NumberBox` numeric inputs and icon hosts, not text-bearing dropdowns.