### PR TITLE
Centralize item removal logic in MyListBox

### DIFF
--- a/ContextMenuManager/BluePointLilac.Controls/MyListBox.cs
+++ b/ContextMenuManager/BluePointLilac.Controls/MyListBox.cs
@@ -96,6 +96,11 @@ namespace ContextMenuManager.Controls
             stackPanel.Children.Insert(index, item.Control);
         }
 
+        public void RemoveItem(MyListItem item)
+        {
+            if (item != null) stackPanel.Children.Remove(item.Control);
+        }
+
         public virtual void ClearItems()
         {
             stackPanel.Children.Clear();

--- a/ContextMenuManager/Controls/GuidBlockedItem.cs
+++ b/ContextMenuManager/Controls/GuidBlockedItem.cs
@@ -116,9 +116,11 @@ namespace ContextMenuManager.Controls
             Array.ForEach(GuidBlockedList.BlockedPaths, path => RegistryEx.DeleteValue(path, Value));
             if (!Guid.Equals(Guid.Empty)) ExplorerRestarter.Show();
             var index = List.GetItemIndex(this);
-            index -= (index < List.Controls.Count - 1) ? 0 : 1;
-            List.Controls.Remove(Control);
-            List.Controls[index]?.Focus();
+            List.RemoveItem(this);
+            if (List.Controls.Count > 0)
+            {
+                List.Controls[Math.Min(index, List.Controls.Count - 1)].Focus();
+            }
             Dispose();
         }
     }

--- a/ContextMenuManager/Controls/Interfaces/ITsiDeleteItem.cs
+++ b/ContextMenuManager/Controls/Interfaces/ITsiDeleteItem.cs
@@ -52,8 +52,11 @@ namespace ContextMenuManager.Controls.Interfaces
                     AppMessageBox.Show(AppString.Message.AuthorityProtection);
                     return;
                 }
-                list.Controls.Remove(listItem.Control);
-                list.Controls[index < list.Controls.Count ? index : (list.Controls.Count - 1)].Focus();
+                list.RemoveItem(listItem);
+                if (list.Controls.Count > 0)
+                {
+                    list.Controls[Math.Min(index, list.Controls.Count - 1)].Focus();
+                }
                 listItem.Dispose();
             };
         }

--- a/ContextMenuManager/Controls/ShellNewItem.cs
+++ b/ContextMenuManager/Controls/ShellNewItem.cs
@@ -331,7 +331,7 @@ namespace ContextMenuManager.Controls
         {
             RegistryEx.DeleteKeyTree(RegPath);
             RegistryEx.DeleteKeyTree(BackupPath);
-            List.Controls.Remove(Control);
+            List.RemoveItem(this);
             if (ShellNewList.ShellNewLockItem.IsLocked) List?.SaveSorting();
         }
 

--- a/ContextMenuManager/Controls/ShellSubMenuDialog.cs
+++ b/ContextMenuManager/Controls/ShellSubMenuDialog.cs
@@ -212,8 +212,8 @@ namespace ContextMenuManager.Controls
                 SubKeyNames.RemoveAt(index - 1);
                 var nextIndex = index;
                 if (index == Controls.Count - 1) nextIndex--;
-                Controls.Remove(item.Control);
-                Controls[nextIndex]?.Focus();
+                RemoveItem(item);
+                if (Controls.Count > 0) Controls[nextIndex].Focus();
                 SaveSorting();
                 item.Dispose();
             }
@@ -500,7 +500,7 @@ namespace ContextMenuManager.Controls
                     var index = List.GetItemIndex(this);
                     if (index == List.Controls.Count - 1) index--;
                     List.Controls[index]?.Focus();
-                    List.Controls.Remove(Control);
+                    List.RemoveItem(this);
                     Dispose();
                 }
             }

--- a/ContextMenuManager/Controls/WinXItem.cs
+++ b/ContextMenuManager/Controls/WinXItem.cs
@@ -302,12 +302,10 @@ namespace ContextMenuManager.Controls
             FilePath = lnkPath;
             RefreshKeyPath();
 
-            List.Controls.Remove(Control);
             for (var i = 0; i < List.Controls.Count; i++)
             {
                 if (List.Controls[i].Item is WinXGroupItem groupItem && groupItem.Text == dlg.Selected)
                 {
-                    List.Controls.Add(Control);
                     List.SetItemIndex(this, i + 1);
                     Visible = !groupItem.IsFold;
                     ((WinXGroupItem)FoldGroupItem).RemoveWinXItem(this);


### PR DESCRIPTION
Refactored item removal by introducing RemoveItem in MyListBox, replacing direct Controls.Remove calls. This centralizes removal logic, reduces duplication, and ensures focus is set appropriately after removal.

Fix #147